### PR TITLE
Exchange Test Code

### DIFF
--- a/marketplace_contract/contracts/WaffleExchange.sol
+++ b/marketplace_contract/contracts/WaffleExchange.sol
@@ -19,6 +19,7 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
     using Counters for Counters.Counter;
     Counters.Counter private _latestOrderId;
 
+    event OrderRegistered(address indexed maker, LibAsset.Asset makerAsset, LibAsset.Asset takerAsset, uint256 id);
     constructor(
         INftTransferProxy nftTransferProxy,
         IERC20TransferProxy erc20TransferProxy,

--- a/marketplace_contract/contracts/WaffleExchange.sol
+++ b/marketplace_contract/contracts/WaffleExchange.sol
@@ -67,9 +67,9 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
     ) external virtual override returns (bool) {
         LibOrder.Order memory order = orderOf[id];
         _validateOrder(order, taker, takerAsset);
-        _matchAndTransfer(order);
         order.taker = taker;
         order.status = LibOrder.OrderStatus.completed;
+        _matchAndTransfer(order);
         return true;
     }
 

--- a/marketplace_contract/contracts/WaffleExchange.sol
+++ b/marketplace_contract/contracts/WaffleExchange.sol
@@ -160,4 +160,8 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
         }
         return 0;
     }
+
+    function getExchangeFee() external view returns (uint8) {
+        return exchangeFeeDenominator;
+    }
 }

--- a/marketplace_contract/contracts/WaffleExchange.sol
+++ b/marketplace_contract/contracts/WaffleExchange.sol
@@ -40,16 +40,23 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
             _getBalance(maker, makerAsset) >= makerAsset.value,
             "maker should have enough asset"
         );
-        orders.push(
-            LibOrder.Order(
-                maker,
-                makerAsset,
-                address(0),
-                takerAsset,
-                id,
-                LibOrder.OrderStatus.onSale
-            )
-        );
+
+        {
+            LibOrder.Order memory newOrder = LibOrder.Order(
+                    maker,
+                    makerAsset,
+                    address(0),
+                    takerAsset,
+                    id,
+                    LibOrder.OrderStatus.onSale
+                );
+
+            orders.push(newOrder);
+            orderOf[id] = newOrder;
+            orderByMaker[maker] = newOrder;
+        }
+
+        emit OrderRegistered(maker, makerAsset, takerAsset, id);
         return id;
     }
 

--- a/marketplace_contract/contracts/interface/IWaffleExchange.sol
+++ b/marketplace_contract/contracts/interface/IWaffleExchange.sol
@@ -7,6 +7,7 @@ import "../util/LibOrder.sol";
 abstract contract IWaffleExchange {
     LibOrder.Order[] public orders;
     mapping(uint256 => LibOrder.Order) public orderOf;
+    mapping(address => LibOrder.Order) public orderByMaker;
 
     /**
      * @dev NFT order 등록

--- a/marketplace_contract/contracts/test/TestERC1155.sol
+++ b/marketplace_contract/contracts/test/TestERC1155.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract TestERC1155 is ERC1155 {
+    constructor(string memory uri) ERC1155(uri) {
+
+    }
+
+    function mint(address account, uint256 tokenId, uint256 amount, bytes memory data) external {
+        _mint(account, tokenId, amount, data);
+    }
+}

--- a/marketplace_contract/contracts/test/TestERC20.sol
+++ b/marketplace_contract/contracts/test/TestERC20.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+
+    }
+
+    function mint(address to, uint amount) external {
+        _mint(to, amount);
+    }
+}

--- a/marketplace_contract/contracts/test/TestERC721.sol
+++ b/marketplace_contract/contracts/test/TestERC721.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract TestERC721 is ERC721 {
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+
+    }
+
+    function mint(address to, uint tokenId, string memory uri) external {
+        _mint(to, tokenId);
+    }
+
+    function burn(uint tokenId) external {
+        _burn(tokenId);
+    }
+}

--- a/marketplace_contract/test/index.ts
+++ b/marketplace_contract/test/index.ts
@@ -10,25 +10,32 @@ describe("WaffleExchange", function () {
   let erc20Proxy: Contract;
   let exchangeAdmin: SignerWithAddress;
   let orderMaker: SignerWithAddress;
-  let ordertkaer: SignerWithAddress;
+  let ordertaker: SignerWithAddress;
 
   let fee: number;
 
   beforeEach(async () => {
-    nftProxy = await (
-      await ethers.getContractFactory("NftTransferProxy")
-    ).deploy();
+    [exchangeAdmin, orderMaker, ordertaker] = await ethers.getSigners();
 
-    erc20Proxy = await (
-      await ethers.getContractFactory("ERC20TransferProxy")
-    ).deploy();
+    nftProxy = await (await ethers.getContractFactory("NftTransferProxy"))
+      .connect(exchangeAdmin)
+      .deploy();
+
+    erc20Proxy = await (await ethers.getContractFactory("ERC20TransferProxy"))
+      .connect(exchangeAdmin)
+      .deploy();
 
     fee = 30;
-    waffleExchange = await (
-      await ethers.getContractFactory("WaffleExchange")
-    ).deploy(nftProxy.address, erc20Proxy.address, fee);
 
-    [exchangeAdmin, orderMaker, ordertkaer] = await ethers.getSigners();
+    waffleExchange = await (await ethers.getContractFactory("WaffleExchange"))
+      .connect(exchangeAdmin)
+      .deploy(nftProxy.address, erc20Proxy.address, fee);
+
+    await nftProxy.connect(exchangeAdmin).__TransferProxy_init();
+    await erc20Proxy.connect(exchangeAdmin).__ERC20TransferProxy_init();
+
+    await nftProxy.connect(exchangeAdmin).addOperator(waffleExchange.address);
+    await erc20Proxy.connect(exchangeAdmin).addOperator(waffleExchange.address);
   });
   it("Should return exchange fee dominator once it's deployed", async function () {
     const exchangeFee = await waffleExchange.getExchangeFee();
@@ -77,6 +84,32 @@ describe("WaffleExchange", function () {
 
     expect(makeAsset).to.eql(registeredOrderMakerAsset);
     expect(takeAsset).to.eql(registeredOrderTakerAsset);
+  });
+  it("Should match order with correct maker asset and taker asset", async function () {
+    const testErc721 = await (
+      await ethers.getContractFactory("TestERC721")
+    ).deploy("testName", "testSymbol");
+
+    testErc721.mint(orderMaker.address, 7, "");
+    testErc721.connect(orderMaker).approve(nftProxy.address, 7);
+
+    const testErc20 = await (
+      await ethers.getContractFactory("TestERC20")
+    ).deploy("waffleCoin", "waffle");
+
+    testErc20.mint(ordertaker.address, 1000);
+    testErc20.connect(ordertaker).approve(erc20Proxy.address, 10);
+
+    const makeAsset = asset(ERC721, encodeAbi(testErc721.address, 7), 1);
+    const takeAsset = asset(ERC20, encodeAbi(testErc20.address), 10);
+
+    await waffleExchange.registerOrder(
+      orderMaker.address,
+      makeAsset,
+      takeAsset
+    );
+
+    await waffleExchange.matchOrder(ordertaker.address, 1, takeAsset);
   });
   it("Should return proxy addresses once it's initilaized or changed", async function () {
     // TODO : proxy 정보를 불러오는 함수를 추가해야 합니다

--- a/marketplace_contract/test/index.ts
+++ b/marketplace_contract/test/index.ts
@@ -1,13 +1,84 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
+import { Contract, ethers as etherjs } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { asset, encodeAbi, ERC721, ERC20 } from "./util/index";
 
 describe("WaffleExchange", function () {
-  it("Should return exchange fee once it's initilaized", async function () {
-    // TODO : 테스트 코드 곶 넣을게요
-    const WaffleExchange = await ethers.getContractFactory("WaffleExchange");
+  let waffleExchange: Contract;
+  let nftProxy: Contract;
+  let erc20Proxy: Contract;
+  let exchangeAdmin: SignerWithAddress;
+  let orderMaker: SignerWithAddress;
+  let ordertkaer: SignerWithAddress;
+
+  let fee: number;
+
+  beforeEach(async () => {
+    nftProxy = await (
+      await ethers.getContractFactory("NftTransferProxy")
+    ).deploy();
+
+    erc20Proxy = await (
+      await ethers.getContractFactory("ERC20TransferProxy")
+    ).deploy();
+
+    fee = 30;
+    waffleExchange = await (
+      await ethers.getContractFactory("WaffleExchange")
+    ).deploy(nftProxy.address, erc20Proxy.address, fee);
+
+    [exchangeAdmin, orderMaker, ordertkaer] = await ethers.getSigners();
+  });
+  it("Should return exchange fee dominator once it's deployed", async function () {
+    const exchangeFee = await waffleExchange.getExchangeFee();
+    expect(fee).to.equal(exchangeFee);
+  });
+  it("Should return regsistered order with maker asset & taker asset", async function () {
+    const testErc721 = await (
+      await ethers.getContractFactory("TestERC721")
+    ).deploy("testName", "testSymbol");
+
+    testErc721.mint(orderMaker.address, 1, "");
+
+    const testErc20 = await (
+      await ethers.getContractFactory("TestERC20")
+    ).deploy("testNameToken", "testSymbolToken");
+
+    const makeAsset = asset(ERC721, encodeAbi(testErc721.address, 1), 1);
+    const takeAsset = asset(ERC20, encodeAbi(testErc20.address), 100);
+
+    // registerOrder() 의 Return 값을 받을 순 없다. Transaction 정보만 받을 수 있다.
+    const txReceipt = await waffleExchange.registerOrder(
+      orderMaker.address,
+      makeAsset,
+      takeAsset
+    );
+
+    const registeredOrder = await waffleExchange.orderByMaker(
+      orderMaker.address
+    );
+
+    const registeredOrderMakerAsset = {
+      assetType: {
+        assetClass: registeredOrder.makerAsset.assetType.assetClass,
+        data: registeredOrder.makerAsset.assetType.data,
+      },
+      value: registeredOrder.makerAsset.value.toNumber(),
+    };
+
+    const registeredOrderTakerAsset = {
+      assetType: {
+        assetClass: registeredOrder.takerAsset.assetType.assetClass,
+        data: registeredOrder.takerAsset.assetType.data,
+      },
+      value: registeredOrder.takerAsset.value.toNumber(),
+    };
+
+    expect(makeAsset).to.eql(registeredOrderMakerAsset);
+    expect(takeAsset).to.eql(registeredOrderTakerAsset);
   });
   it("Should return proxy addresses once it's initilaized or changed", async function () {
-    // TODO : 테스트 코드 곶 넣을게요
-    const WaffleExchange = await ethers.getContractFactory("WaffleExchange");
+    // TODO : proxy 정보를 불러오는 함수를 추가해야 합니다
   });
 });

--- a/marketplace_contract/test/util/index.ts
+++ b/marketplace_contract/test/util/index.ts
@@ -1,0 +1,28 @@
+import { ethers } from "ethers";
+import { AbiCoder } from "ethers/lib/utils";
+
+export const convertToKeccak4bytes = (value: string) => {
+  return `${ethers.utils.id(value).substring(0, 10)}`;
+};
+
+export const ERC721 = convertToKeccak4bytes("ERC721");
+export const ERC20 = convertToKeccak4bytes("ERC20");
+
+export const asset = (assetClass: string, assetData: string, value: number) => {
+  return {
+    assetType: {
+      assetClass: assetClass,
+      data: assetData,
+    },
+    value,
+  };
+};
+
+export const encodeAbi = (tokenAddress: string, tokenId?: number) => {
+  const abiCoder = new AbiCoder();
+  if (tokenId) {
+    return abiCoder.encode(["address", "uint256"], [tokenAddress, tokenId]);
+  } else {
+    return abiCoder.encode(["address"], [tokenAddress]);
+  }
+};


### PR DESCRIPTION
### Test code 추가
- Proxy 컨트랙트, Exchange 컨트랙트를 배포하고 연결
- makerAsset, takerAsset을 넣어 Exchange의 registerOrder가 정상 동작하는 것 확인
- matchOrder 정상 동작 확인
- Test를 위해 Test Token 파일을 추가

### 컨트랙트 코드 일부 수정
- 테스트를 짜면서 빠진 부분 확인하여 추가. 컨트랙트에서 array를 리턴하는 방법은 없기에 이부분은 테스트 불가능
- Transaction을 보내는 함수 콜은 Return 값을 받을 수 없음. 그래서 registerOrder의 리턴 값인 id를 받아 처리하는 로직이 불가능한ㅁ
- OrderRegistered 를 추가 -> 추후에 등록된 Order를 쿼리하는 용도로도 사용할 수 있을 것 같음