### PR TITLE
Fix deploy.ts & Add verify scripts

### DIFF
--- a/marketplace_contract/package.json
+++ b/marketplace_contract/package.json
@@ -6,7 +6,9 @@
     "deploy:ropsten": "hardhat run --network ropsten scripts/deploy.ts",
     "deploy:mainnet": "hardhat run --network mainnet scripts/deploy.ts",
     "deploy:local": "hardhat run --network localhost scripts/deploy.ts",
-    "get-accounts": "hardhat accounts"
+    "get-accounts": "hardhat accounts",
+    "verify:ropsten": "npx hardhat verify --network ropsten",
+    "verify:mainnet": "npx hardhat verify --network mainnet"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.4",

--- a/marketplace_contract/scripts/deploy.ts
+++ b/marketplace_contract/scripts/deploy.ts
@@ -6,27 +6,8 @@
 import { ethers } from "hardhat";
 
 async function main() {
-  // Hardhat always runs the compile task when running scripts with its command
-  // line interface.
-  //
-  // If this script is run directly using `node` you may want to call compile
-  // manually to make sure everything is compiled
-  // await hre.run('compile');
-
-  // We get the contract to deploy
-  // const WaffleExchange = await ethers.getContractFactory("WaffleExchange");
-  // // FIXME: nftProxy address, erc20Proxy address
-  // const waffleExchange = await WaffleExchange.deploy("0", "0", 30);
-
-  // await waffleExchange.deployed();
   console.log("on deploying...");
 
-  // const nftProxyFactory = await ethers.getContractFactory("NftTransferProxy");
-  // const nftProxy = await nftProxyFactory.deploy();
-  // console.log("야야...");
-  // console.log(nftProxy);
-
-  // await nftProxy.deployed();
   const nftProxy = await (
     await ethers.getContractFactory("NftTransferProxy")
   ).deploy();
@@ -57,8 +38,7 @@ async function main() {
   await nftProxy.addOperator(waffleExchange.address);
   await erc20Proxy.addOperator(waffleExchange.address);
   console.log("waffleExchange added to proxies as operator");
-
-  console.log("WaffleExchange deployed to:", waffleExchange.address);
+  console.log("Contracts deployment and proxy setting completed");
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION
이전 PR에 같이 들어가버린 deploy.ts 로그만 약간 수정했습니다.
Etherscan에서 verify하기 위한 script를 추가했습니다.

배포 방법 
:`yarn deploy:ropsten`
verify 방법 (예시)
:`yarn verify:ropsten 0x772DC60fE0c93D5D5a71a3160283c81dAd786BBA "0xf5B76024765Bd84917701E740CE4Be434DA5de1A" "0x449845B00eE150EFc3aa89d120FC41dA02017554" "30"`
(contract address와 constructor argument 3개 넣습니다)

.env 파일에 각자 url이랑 key 넣어야 합니다

