### PR TITLE
fix: allow order cancellation to owner

### DIFF
--- a/marketplace_contract/contracts/WaffleExchange.sol
+++ b/marketplace_contract/contracts/WaffleExchange.sol
@@ -82,8 +82,8 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
     {
         LibOrder.Order memory order = orderOf[id];
         require(
-            order.maker == msg.sender,
-            "message sender should be maker of the order"
+            order.maker == msg.sender || owner() == msg.sender,
+            "message sender should be maker of the order or the contract owner"
         );
         require(order.maker == maker, "maker of the order should match maker");
         require(
@@ -113,7 +113,8 @@ contract WaffleExchange is WaffleExchangeProxyHandler, IWaffleExchange {
         );
         require(
             order.takeAsset.assetType.assetClass ==
-                takeAsset.assetType.assetClass
+                takeAsset.assetType.assetClass,
+            "takeasset should match"
         );
         require(
             keccak256(abi.encodePacked(order.takeAsset.assetType.data)) ==


### PR DESCRIPTION
작은 변경과 함께, feature 제안이 있습니다.

Proxy 에서 사용하는 OperatorRole 과 비슷한 구현으로 marketplace 관리자 role 추가를 제안합니다.

마켓플레이스 관리자는 특정 오더를 cancel 하는 권한을 가져, 부적절한 미디어의 노출을 방지합니다.
추가적인 기능으로는 특정 유저에 대한 토큰 등록 ban 도 도입이 가능할것 같습니다.